### PR TITLE
feat: Add “Add to Past Events” Feature for Club Event Timeline

### DIFF
--- a/app/(public)/clubs/[slug]/page.tsx
+++ b/app/(public)/clubs/[slug]/page.tsx
@@ -141,134 +141,16 @@ const CLUBS_DATA: Record<string, any> = {
     }
 }
 
-// Hardcoded Legacy Events (History) - Verified from Technical Society
+// Legacy Events - Cleared. Past events will now come from the database via "Add to Past Events" feature.
 const LEGACY_EVENTS: Record<string, any[]> = {
-    "cyber-pirates": [
-        {
-            id: "legacy-1",
-            title: "Hack-a-Phone",
-            description: "A remarkable gathering showcasing live demonstrations of phone hacking techniques. Conducted by Club Co-Lead Mr. Pranaav Bhatnagar and Ms. Chetna Talan, providing valuable insights on maintaining personal safety in the digital realm.",
-            start_time: "2023-06-12T10:00:00Z",
-            end_time: "2023-06-12T16:00:00Z",
-            venue: "Auditorium",
-            gallery: ["https://images.unsplash.com/photo-1550751827-4bd374c3f58b?auto=format&fit=crop&q=80&w=2670", "https://images.unsplash.com/photo-1526374965328-7f61d4dc18c5?auto=format&fit=crop&q=80&w=2670"],
-            banner: "https://images.unsplash.com/photo-1563206767-5b18f218e8de?auto=format&fit=crop&q=80&w=2669",
-            isLegacy: true
-        },
-        {
-            id: "legacy-2",
-            title: "Cyber Security Workshop",
-            description: "A successful hands-on workshop for Computer Science students. Instructors Abhishek Kumar Singh and Abhishek Gupta introduced Linux training with surging enthusiasm.",
-            start_time: "2022-07-09T10:00:00Z",
-            end_time: "2022-07-09T16:00:00Z",
-            venue: "School of Engineering",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        },
-        {
-            id: "legacy-3",
-            title: "Linux Training",
-            description: "An introductory session on Linux commands and file systems for beginners.",
-            start_time: "2022-04-11T10:00:00Z",
-            end_time: "2022-04-12T16:00:00Z",
-            venue: "Online",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ],
-    "ai-robotics": [
-        {
-            id: "legacy-ai-1",
-            title: "Star Grazing",
-            description: "Showcasing student-built autonomous rovers and drones. A day filled with innovation and mechanical engineering marvels.",
-            start_time: "2023-09-15T10:00:00Z",
-            end_time: "2023-09-15T16:00:00Z",
-            venue: "Main Ground",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ],
-    "aws-cloud": [
-        {
-            id: "legacy-aws-1",
-            title: "AWS Cloud Day",
-            description: "Deep dive into Serverless architectures and EC2 instance management. Guest speakers from AWS Community Builders.",
-            start_time: "2023-08-20T10:00:00Z",
-            end_time: "2023-08-20T16:00:00Z",
-            venue: "Seminar Hall 1",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ],
-    "datapool": [
-        {
-            id: "legacy-data-1",
-            title: "Big Data Summit",
-            description: "Analyzing real-world datasets using Python and R. Insights into Data Engineering career paths.",
-            start_time: "2023-10-05T10:00:00Z",
-            end_time: "2023-10-05T16:00:00Z",
-            venue: "Lab 3",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ],
-    "game-drifters": [
-        {
-            id: "legacy-game-1",
-            title: "Technova E-Sports Cup",
-            description: "Inter-college Valorant and BGMI tournament. Over 50 teams participated for the grand prize.",
-            start_time: "2023-11-10T10:00:00Z",
-            end_time: "2023-11-12T16:00:00Z",
-            venue: "Gaming Room",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ],
-    "github": [
-        {
-            id: "legacy-git-1",
-            title: "Open Source October",
-            description: "Introduction to Git, GitHub, and creating your first Pull Request. Celebrating Hacktoberfest.",
-            start_time: "2023-10-01T10:00:00Z",
-            end_time: "2023-10-01T16:00:00Z",
-            venue: "Computer Lab 1",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ],
-    "gdg": [
-        {
-            id: "legacy-gdg-1",
-            title: "Google I/O Extended",
-            description: "Watch party and technical discussions on the latest announcements from Google I/O 2023.",
-            start_time: "2023-05-25T18:00:00Z",
-            end_time: "2023-05-25T21:00:00Z",
-            venue: "Auditorium",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ],
-    "pixelance": [
-        {
-            id: "legacy-pix-1",
-            title: "Photo Walk: Old Delhi",
-            description: "Capturing the heritage and streets of Old Delhi. Workshop on street photography basics.",
-            start_time: "2023-12-05T07:00:00Z",
-            end_time: "2023-12-05T14:00:00Z",
-            venue: "Old Delhi",
-            gallery: [],
-            banner: null,
-            isLegacy: true
-        }
-    ]
+    "cyber-pirates": [],
+    "ai-robotics": [],
+    "aws-cloud": [],
+    "datapool": [],
+    "game-drifters": [],
+    "github": [],
+    "gdg": [],
+    "pixelance": []
 }
 
 export default async function ClubDetailsPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CheckCircle, XCircle, X } from 'lucide-react'
+
+interface ToastProps {
+    message: string
+    type: 'success' | 'error'
+    onClose: () => void
+    duration?: number
+}
+
+export function Toast({ message, type, onClose, duration = 3000 }: ToastProps) {
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            onClose()
+        }, duration)
+
+        return () => clearTimeout(timer)
+    }, [duration, onClose])
+
+    return (
+        <div className={`fixed bottom-6 right-6 z-50 flex items-center gap-3 px-4 py-3 rounded-xl shadow-2xl backdrop-blur-xl border animate-in slide-in-from-bottom-4 fade-in duration-300 ${type === 'success'
+                ? 'bg-green-500/20 border-green-500/30 text-green-400'
+                : 'bg-red-500/20 border-red-500/30 text-red-400'
+            }`}>
+            {type === 'success' ? (
+                <CheckCircle className="w-5 h-5 flex-shrink-0" />
+            ) : (
+                <XCircle className="w-5 h-5 flex-shrink-0" />
+            )}
+            <span className="text-sm font-medium">{message}</span>
+            <button
+                onClick={onClose}
+                className="ml-2 p-1 hover:bg-white/10 rounded-lg transition-colors"
+            >
+                <X className="w-4 h-4" />
+            </button>
+        </div>
+    )
+}
+
+// Toast hook for managing toast state
+export function useToast() {
+    const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null)
+
+    const showToast = (message: string, type: 'success' | 'error') => {
+        setToast({ message, type })
+    }
+
+    const hideToast = () => {
+        setToast(null)
+    }
+
+    return { toast, showToast, hideToast }
+}

--- a/lib/actions/club-events.ts
+++ b/lib/actions/club-events.ts
@@ -31,14 +31,12 @@ export async function getPastEvents(slug: string) {
     if (!club) return []
 
     // 2. Get Past Events for this Club (or Co-Hosted)
-    // "Past" means end_time has passed.
-    const now = new Date().toISOString()
-
+    // Only show events that are EXPLICITLY marked as past by admins via is_past_event flag
     const { data: events } = await supabase.from('events')
         .select('*')
         .or(`club_id.eq.${club.id},co_host_club_id.eq.${club.id}`)
-        .lt('end_time', now)
         .eq('status', 'live') // Only public events
+        .eq('is_past_event', true) // Only events explicitly marked as past
         .order('end_time', { ascending: false })
 
     return events || []

--- a/supabase/migrations/0011_add_is_past_event.sql
+++ b/supabase/migrations/0011_add_is_past_event.sql
@@ -1,0 +1,9 @@
+-- ==========================================
+-- Add is_past_event flag to events table
+-- Allows admins to explicitly mark events as "past" for club timeline display
+-- ==========================================
+
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS is_past_event boolean DEFAULT false;
+
+-- Add comment for documentation
+COMMENT ON COLUMN public.events.is_past_event IS 'Flag to explicitly mark event as past for display in club timeline. Can be set by admins after event completion.';


### PR DESCRIPTION
## Add "Add to Past Events" Feature for Club Event Timeline

### Description
This PR introduces the ability for administrators to manage events appearing in a club’s **Past Events Timeline**. Admins can now easily add completed events to the club timeline or remove them using a simple toggle button on the event admin page.

---

### Problem
Previously, admins had **no direct control** over which completed events appeared in the club timeline.  
Any update required **manual database edits**, which was inefficient and prone to errors.

---

### Solution
This PR adds:
- A toggle button on the Admin Event Detail page.
- Ability to mark/unmark events as past timeline events.
- Secure server-side handling with role-based authorization.
- Instant UI feedback with toast notifications.

---

### Changes Made

#### **Database**
- Added `is_past_event` boolean column
  - Migration: `0011_add_is_past_event.sql`

#### **Backend**
- `lib/actions/events.ts`
  - Added `togglePastEvent()` with admin authorization check
- `lib/actions/club-events.ts`
  - Updated `getPastEvents()` to filter `is_past_event = true`

#### **Frontend**
- `app/(admin)/admin/events/[id]/client.tsx`
  - Added toggle button with:
    - “Add to Past Events”
    - “Remove from Timeline”
    - Loading + success states
- `components/ui/toast.tsx`
  - Added toast notifications for feedback

#### **Other**
- Removed legacy hardcoded past events from:
  - `app/(public)/clubs/[slug]/page.

---

### Testing Checklist
- [x] Button visible only to `admin/super_admin`
- [x] Button only visible if event has ended
- [x] Can add event to timeline
- [x] Can remove event from timeline
- [x] Success toast appears
- [x] Confirmation modal prevents mistakes
- [x] Timeline updates correctly
- [x] Responsive (Mobile + Desktop)
- [x] No regression in existing event features