### PR TITLE
fix: daily XP distribution for multi-day events

### DIFF
--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
-import { awardXPForAttendance } from '@/lib/xp'
+import { awardDailyXP } from '@/lib/xp'
 import { hasSubmittedEventFeedback } from '@/lib/actions/feedback'
 import { auth } from '@/lib/auth'
 import { checkRateLimit, getClientIdentifier } from '@/lib/rate-limit'
@@ -94,8 +94,8 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ success: false, message: 'Failed to update' }, { status: 500 })
         }
 
-        // 4. Award XP for attendance
-        const xpResult = await awardXPForAttendance(userId, eventId, {
+        // 4. Award daily XP for attendance (distributes XP across event days)
+        const xpResult = await awardDailyXP(userId, eventId, {
             event_type: registration.events?.event_type,
             difficulty_level: registration.events?.difficulty_level,
             start_time: registration.events?.start_time,
@@ -116,7 +116,12 @@ export async function POST(req: NextRequest) {
             message: 'Check-in successful',
             userName: user?.name || 'Attendee',
             xpAwarded: xpResult.xpAwarded,
-            xpMessage: xpResult.message
+            xpMessage: xpResult.message,
+            // Daily XP distribution info
+            dailyXP: xpResult.dailyXP,
+            eventDays: xpResult.eventDays,
+            daysCheckedIn: xpResult.daysCheckedIn,
+            remainingDays: xpResult.remainingDays
         })
 
     } catch (err) {

--- a/docs/XP_REWARDS.md
+++ b/docs/XP_REWARDS.md
@@ -73,6 +73,33 @@ The following examples illustrate sample XP awards:
 
 ---
 
+## **Daily XP Distribution**
+
+For events spanning multiple days, XP is **distributed daily** rather than awarded all at once. This encourages consistent participation throughout the event.
+
+### **How It Works**
+
+1. **Total XP is calculated** using the standard formula
+2. **Daily XP is computed**: `Daily XP = Total XP ÷ Number of Event Days`
+3. **Participants earn XP each day** they check in to the event
+4. **Missed days = lost XP** — each day's XP chunk is only available on that day
+
+### **Example: 3-Day Hackathon (Elite)**
+
+| Metric        | Value                |
+| ------------- | -------------------- |
+| Total XP      | 900 XP               |
+| Event Days    | 3                    |
+| Daily XP      | 300 XP/day           |
+| Day 1 Check-in | +300 XP             |
+| Day 2 Missed  | 0 XP (lost)          |
+| Day 3 Check-in | +300 XP             |
+| **Total Earned** | **600 XP**       |
+
+> **Note:** On the final check-in day, any remaining XP is awarded to ensure no rounding loss.
+
+---
+
 ## **Earning XP**
 
 Students earn XP through verified participation in events.

--- a/lib/actions/community.ts
+++ b/lib/actions/community.ts
@@ -31,7 +31,7 @@ export async function createPost(prevState: any, formData: FormData) {
     });
 
     if (!result.success) {
-        return { error: result.error.errors[0].message };
+        return { error: result.error.issues[0]?.message || "Validation failed" };
     }
 
     const { title, content, category } = result.data;
@@ -180,7 +180,7 @@ export async function addComment(prevState: any, formData: FormData) {
     });
 
     if (!result.success) {
-        return { error: result.error.errors[0].message };
+        return { error: result.error.issues[0]?.message || "Validation failed" };
     }
 
     const { content, postId } = result.data;

--- a/lib/actions/feedback.ts
+++ b/lib/actions/feedback.ts
@@ -553,10 +553,10 @@ export async function submitFeedback(formId: string, answers: Record<string, any
 
         if (!attendError) {
             attendanceMarked = true
-            // Award XP for attendance as well
+            // Award XP for attendance as well (using daily XP distribution)
             try {
-                const { awardXPForAttendance } = await import('@/lib/xp/award')
-                await awardXPForAttendance(session.user.id, form.event_id, {
+                const { awardDailyXP } = await import('@/lib/xp/award')
+                await awardDailyXP(session.user.id, form.event_id, {
                     event_type: form.event.event_type || 'workshop',
                     difficulty_level: form.event.difficulty_level || 'easy',
                     start_time: form.event.start_time,

--- a/lib/actions/resources.ts
+++ b/lib/actions/resources.ts
@@ -38,7 +38,7 @@ export async function createResource(prevState: any, formData: FormData) {
     });
 
     if (!result.success) {
-        return { error: result.error.errors[0].message };
+        return { error: result.error.issues[0]?.message || "Validation failed" };
     }
 
     const { title, description, file_url, type, semester, subject } = result.data;

--- a/lib/xp/award.ts
+++ b/lib/xp/award.ts
@@ -187,3 +187,210 @@ export async function getEventXPAwards(eventId: string): Promise<{ userId: strin
         amount: award.xp_amount
     }))
 }
+
+// ==========================================
+// Daily XP Distribution Functions
+// ==========================================
+
+/**
+ * Check if user already checked in for a specific date
+ */
+export async function hasDailyCheckin(
+    userId: string,
+    eventId: string,
+    checkinDate: Date
+): Promise<boolean> {
+    const supabase = getSupabase()
+
+    // Format date as YYYY-MM-DD for database comparison
+    const dateStr = checkinDate.toISOString().split('T')[0]
+
+    const { data } = await supabase
+        .from('daily_checkins')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .eq('checkin_date', dateStr)
+        .single()
+
+    return !!data
+}
+
+/**
+ * Get all daily check-ins for a user and event
+ */
+export async function getUserDailyCheckinsForEvent(
+    userId: string,
+    eventId: string
+): Promise<{ date: string; xpAwarded: number }[]> {
+    const supabase = getSupabase()
+
+    const { data, error } = await supabase
+        .from('daily_checkins')
+        .select('checkin_date, xp_awarded')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .order('checkin_date', { ascending: true })
+
+    if (error || !data) {
+        return []
+    }
+
+    return data.map(checkin => ({
+        date: checkin.checkin_date,
+        xpAwarded: checkin.xp_awarded
+    }))
+}
+
+/**
+ * Extended result for daily XP award
+ */
+export interface DailyXPAwardResult extends XPAwardResult {
+    dailyXP: number
+    eventDays: number
+    totalXP: number
+    daysCheckedIn: number
+    remainingDays: number
+}
+
+/**
+ * Award daily XP chunk for a specific day's check-in
+ * 
+ * This function:
+ * 1. Calculates total event XP using the standard formula
+ * 2. Divides it by the number of event days
+ * 3. Awards one daily chunk per check-in
+ * 4. Handles remainder XP on the last valid check-in day
+ */
+export async function awardDailyXP(
+    userId: string,
+    eventId: string,
+    eventData: EventXPData,
+    checkinDate: Date = new Date()
+): Promise<DailyXPAwardResult> {
+    const supabase = getSupabase()
+
+    // 1. Validate event data
+    if (!canCalculateXP(eventData)) {
+        return {
+            success: false,
+            xpAwarded: 0,
+            dailyXP: 0,
+            eventDays: 0,
+            totalXP: 0,
+            daysCheckedIn: 0,
+            remainingDays: 0,
+            message: 'Event missing required fields for XP calculation'
+        }
+    }
+
+    // 2. Calculate total XP and daily distribution
+    const { finalXP, dailyXP, eventDays, breakdown } = calculateEventXP(eventData)
+
+    // 3. Format check-in date
+    const dateStr = checkinDate.toISOString().split('T')[0]
+
+    // 4. Check if already checked in today
+    const alreadyCheckedIn = await hasDailyCheckin(userId, eventId, checkinDate)
+    if (alreadyCheckedIn) {
+        const existingCheckins = await getUserDailyCheckinsForEvent(userId, eventId)
+        return {
+            success: false,
+            xpAwarded: 0,
+            dailyXP,
+            eventDays,
+            totalXP: finalXP,
+            daysCheckedIn: existingCheckins.length,
+            remainingDays: eventDays - existingCheckins.length,
+            message: 'Already checked in today'
+        }
+    }
+
+    // 5. Get existing check-ins to determine if this is the last day
+    const existingCheckins = await getUserDailyCheckinsForEvent(userId, eventId)
+    const daysCheckedIn = existingCheckins.length
+    const totalAwarded = existingCheckins.reduce((sum, c) => sum + c.xpAwarded, 0)
+
+    // Calculate XP to award this check-in
+    // On the last possible check-in, award remaining XP to avoid rounding loss
+    let xpToAward = dailyXP
+    const isLastPossibleDay = daysCheckedIn + 1 >= eventDays
+    if (isLastPossibleDay) {
+        // Award all remaining XP on last day
+        xpToAward = finalXP - totalAwarded
+    }
+
+    // 6. Record daily check-in
+    const { error: checkinError } = await supabase
+        .from('daily_checkins')
+        .insert({
+            user_id: userId,
+            event_id: eventId,
+            checkin_date: dateStr,
+            xp_awarded: xpToAward
+        })
+
+    if (checkinError) {
+        // Handle unique constraint violation (race condition)
+        if (checkinError.code === '23505') {
+            return {
+                success: false,
+                xpAwarded: 0,
+                dailyXP,
+                eventDays,
+                totalXP: finalXP,
+                daysCheckedIn,
+                remainingDays: eventDays - daysCheckedIn,
+                message: 'Already checked in today'
+            }
+        }
+        console.error('Daily Check-in Error:', checkinError)
+        return {
+            success: false,
+            xpAwarded: 0,
+            dailyXP,
+            eventDays,
+            totalXP: finalXP,
+            daysCheckedIn,
+            remainingDays: eventDays - daysCheckedIn,
+            message: 'Failed to record daily check-in'
+        }
+    }
+
+    // 7. Update user's total XP points
+    const { data: user } = await supabase
+        .schema('next_auth' as unknown as 'public')
+        .from('users')
+        .select('xp_points')
+        .eq('id', userId)
+        .single()
+
+    const currentXP = user?.xp_points || 0
+    const newXP = currentXP + xpToAward
+
+    const { error: updateError } = await supabase
+        .schema('next_auth' as unknown as 'public')
+        .from('users')
+        .update({ xp_points: newXP })
+        .eq('id', userId)
+
+    if (updateError) {
+        console.error('XP Update Error:', updateError)
+        // Check-in was recorded, so we continue even if user XP update fails
+    }
+
+    const newDaysCheckedIn = daysCheckedIn + 1
+    const remainingDays = Math.max(0, eventDays - newDaysCheckedIn)
+
+    return {
+        success: true,
+        xpAwarded: xpToAward,
+        dailyXP,
+        eventDays,
+        totalXP: finalXP,
+        daysCheckedIn: newDaysCheckedIn,
+        remainingDays,
+        message: `Awarded ${xpToAward} XP (Day ${newDaysCheckedIn}/${eventDays})`,
+        breakdown
+    }
+}

--- a/lib/xp/calculator.ts
+++ b/lib/xp/calculator.ts
@@ -137,6 +137,34 @@ export function getDurationLabel(
     }
 }
 
+/**
+ * Calculate the number of days for an event
+ * Used for daily XP distribution
+ */
+export function getEventDayCount(
+    startTime: string,
+    endTime: string,
+    isMultiDay?: boolean
+): number {
+    try {
+        const start = new Date(startTime)
+        const end = new Date(endTime)
+
+        // Reset to start of day for accurate day count
+        const startDay = new Date(start.getFullYear(), start.getMonth(), start.getDate())
+        const endDay = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+
+        // Calculate difference in days
+        const diffMs = endDay.getTime() - startDay.getTime()
+        const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24)) + 1  // +1 because both start and end day count
+
+        // Minimum 1 day
+        return Math.max(1, diffDays)
+    } catch {
+        return 1  // Default to single day on parse error
+    }
+}
+
 // ==========================================
 // Difficulty Multiplier
 // ==========================================
@@ -169,6 +197,9 @@ export interface XPCalculationResult {
     difficultyMultiplier: number
     finalXP: number
     breakdown: string
+    // Daily XP distribution fields
+    eventDays: number
+    dailyXP: number
 }
 
 /**
@@ -187,15 +218,21 @@ export function calculateEventXP(event: EventXPData): XPCalculationResult {
     // Calculate final XP (rounded to nearest integer)
     const finalXP = Math.round(baseXP * durationMultiplier * difficultyMultiplier)
 
+    // Calculate event days and daily XP for distribution
+    const eventDays = getEventDayCount(event.start_time, event.end_time, event.is_multi_day)
+    const dailyXP = Math.floor(finalXP / eventDays)
+
     // Generate breakdown string for display/logging
-    const breakdown = `${baseXP} × ${durationMultiplier} × ${difficultyMultiplier} = ${finalXP} XP`
+    const breakdown = `${baseXP} × ${durationMultiplier} × ${difficultyMultiplier} = ${finalXP} XP (${dailyXP} XP/day × ${eventDays} days)`
 
     return {
         baseXP,
         durationMultiplier,
         difficultyMultiplier,
         finalXP,
-        breakdown
+        breakdown,
+        eventDays,
+        dailyXP
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3858,6 +3859,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.89.0.tgz",
       "integrity": "sha512-KlaRwSfFA0fD73PYVMHj5/iXFtQGCcX7PSx0FdQwYEEw9b2wqM7GxadY+5YwcmuEhalmjFB/YvqaoNVF+sWUlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.89.0",
         "@supabase/functions-js": "2.89.0",
@@ -4030,6 +4032,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4041,6 +4044,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4111,6 +4115,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -4623,6 +4628,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5106,6 +5112,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6391,6 +6398,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6576,6 +6584,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9128,6 +9137,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9297,6 +9307,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9478,6 +9489,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9624,6 +9636,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9636,6 +9649,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9718,7 +9732,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-promise-suspense": {
       "version": "0.3.4",
@@ -9740,6 +9755,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9883,7 +9899,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -10889,6 +10906,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11086,6 +11104,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11268,6 +11287,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11979,6 +11999,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/test-daily-xp.js
+++ b/scripts/test-daily-xp.js
@@ -1,0 +1,126 @@
+/**
+ * Daily XP Distribution Test Script
+ * 
+ * Tests the new daily XP calculation logic
+ * Run: node scripts/test-daily-xp.js
+ */
+
+// Simulate the daily XP calculation logic
+// In production, this is in lib/xp/calculator.ts
+
+function getEventDayCount(startTime, endTime) {
+    const start = new Date(startTime);
+    const end = new Date(endTime);
+
+    // Reset to start of day for accurate day count
+    const startDay = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+    const endDay = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+
+    // Calculate difference in days
+    const diffMs = endDay.getTime() - startDay.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24)) + 1;
+
+    return Math.max(1, diffDays);
+}
+
+function calculateDailyXP(totalXP, eventDays) {
+    return Math.floor(totalXP / eventDays);
+}
+
+// Test Cases
+console.log('========================================');
+console.log('Daily XP Distribution Test Suite');
+console.log('========================================\n');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, actual, expected) {
+    if (actual === expected) {
+        console.log(`✅ PASS: ${name}`);
+        console.log(`   Expected: ${expected}, Got: ${actual}\n`);
+        passed++;
+    } else {
+        console.log(`❌ FAIL: ${name}`);
+        console.log(`   Expected: ${expected}, Got: ${actual}\n`);
+        failed++;
+    }
+}
+
+// Event Day Count Tests
+console.log('--- Event Day Count Tests ---');
+test('Single day event (same date)',
+    getEventDayCount('2025-01-01T10:00:00', '2025-01-01T18:00:00'),
+    1);
+
+test('2-day event',
+    getEventDayCount('2025-01-01T10:00:00', '2025-01-02T18:00:00'),
+    2);
+
+test('3-day event',
+    getEventDayCount('2025-01-01T10:00:00', '2025-01-03T18:00:00'),
+    3);
+
+test('5-day event',
+    getEventDayCount('2025-01-01T10:00:00', '2025-01-05T18:00:00'),
+    5);
+
+test('Week-long event (7 days)',
+    getEventDayCount('2025-01-01T10:00:00', '2025-01-07T18:00:00'),
+    7);
+
+// Daily XP Calculation Tests
+console.log('--- Daily XP Calculation Tests ---');
+test('900 XP / 3 days = 300/day',
+    calculateDailyXP(900, 3),
+    300);
+
+test('720 XP / 3 days = 240/day',
+    calculateDailyXP(720, 3),
+    240);
+
+test('80 XP / 1 day = 80/day',
+    calculateDailyXP(80, 1),
+    80);
+
+test('100 XP / 2 days = 50/day',
+    calculateDailyXP(100, 2),
+    50);
+
+// Rounding test (floor)
+test('100 XP / 3 days = 33/day (floor)',
+    calculateDailyXP(100, 3),
+    33);
+
+// Real World Scenarios
+console.log('--- Real World Scenarios ---');
+
+// 3-day Hackathon Elite: 900 XP total
+const hackathonXP = 900;
+const hackathonDays = getEventDayCount('2025-01-01T10:00:00', '2025-01-03T18:00:00');
+const hackathonDailyXP = calculateDailyXP(hackathonXP, hackathonDays);
+test('Hackathon event days', hackathonDays, 3);
+test('Hackathon daily XP', hackathonDailyXP, 300);
+test('Hackathon total if all days checked in', hackathonDailyXP * hackathonDays, 900);
+
+// Remainder handling scenario
+// If user checks in 2 of 3 days, they get 600 XP (lost 300)
+const missedDayXP = hackathonDailyXP * 2;
+test('Hackathon XP if missed 1 day', missedDayXP, 600);
+
+// Last day remainder handling
+// 100 XP / 3 days = 33/day, last day should get 34 (100 - 33 - 33 = 34)
+const totalWith100 = 100;
+const daysFor100 = 3;
+const dailyFor100 = calculateDailyXP(totalWith100, daysFor100); // 33
+const lastDayXP = totalWith100 - (dailyFor100 * (daysFor100 - 1)); // 100 - 66 = 34
+test('Last day gets remainder (100 XP / 3 days)', lastDayXP, 34);
+
+// Summary
+console.log('========================================');
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log('========================================');
+
+if (failed > 0) {
+    process.exit(1);
+}

--- a/supabase/migrations/0017_add_daily_checkins.sql
+++ b/supabase/migrations/0017_add_daily_checkins.sql
@@ -1,0 +1,38 @@
+-- ==========================================
+-- Migration: Add Daily Check-ins Table
+-- Tracks daily XP awards for multi-day events
+-- Participants receive XP chunk per day of check-in
+-- ==========================================
+
+-- Daily check-ins table - tracks per-day attendance and XP
+CREATE TABLE IF NOT EXISTS public.daily_checkins (
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    user_id uuid NOT NULL,  -- References next_auth.users.id
+    event_id uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+    checkin_date date NOT NULL,  -- Just the date portion
+    xp_awarded int NOT NULL,
+    created_at timestamptz DEFAULT now(),
+    -- One check-in per user per event per day
+    UNIQUE(user_id, event_id, checkin_date)
+);
+
+-- Add comments for documentation
+COMMENT ON TABLE public.daily_checkins IS 'Tracks daily check-ins for XP distribution. Each day awards a chunk of total event XP.';
+COMMENT ON COLUMN public.daily_checkins.checkin_date IS 'The calendar date of check-in (not time). Used to limit one check-in per day.';
+COMMENT ON COLUMN public.daily_checkins.xp_awarded IS 'The XP chunk awarded for this specific day check-in.';
+
+-- Enable RLS on daily_checkins
+ALTER TABLE public.daily_checkins ENABLE ROW LEVEL SECURITY;
+
+-- Allow service_role full access (server-side operations only)
+CREATE POLICY "Service role full access to daily_checkins" ON public.daily_checkins
+    FOR ALL USING (true) WITH CHECK (true);
+
+-- Add indexes for faster lookups
+CREATE INDEX IF NOT EXISTS idx_daily_checkins_user_event ON public.daily_checkins(user_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_daily_checkins_user_event_date ON public.daily_checkins(user_id, event_id, checkin_date);
+CREATE INDEX IF NOT EXISTS idx_daily_checkins_user ON public.daily_checkins(user_id);
+
+-- Grant permissions
+GRANT ALL ON TABLE public.daily_checkins TO postgres;
+GRANT ALL ON TABLE public.daily_checkins TO service_role;


### PR DESCRIPTION
This PR modifies the XP distribution logic to split total event XP across event days, rewarding participants for each daily check-in rather than awarding all XP at once.

Problem
Previously, participants received their entire event XP upon first check-in, regardless of event duration. This didn't incentivize consistent attendance for multi-day events.

Solution
Daily XP Distribution: Daily XP = Total XP ÷ Number of Event Days
Participants earn XP each day they check in
Missed days = lost XP (encourages consistent participation)
Last day awards remaining XP to handle rounding
