### PR TITLE
feat: Added manual check-in button

### DIFF
--- a/app/(scanner)/scan/page.tsx
+++ b/app/(scanner)/scan/page.tsx
@@ -6,7 +6,7 @@ import { Html5Qrcode, Html5QrcodeSupportedFormats } from 'html5-qrcode'
 import jsQR from 'jsqr'
 import {
     CheckCircle, XCircle, Camera, Loader2, Upload, RefreshCw, ArrowLeft,
-    Users, UserCheck, Search, ChevronDown, Clock, QrCode, List
+    Users, UserCheck, Search, ChevronDown, Clock, QrCode, List, UserPlus
 } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -42,6 +42,8 @@ export default function ScannerPage() {
     const [searchQuery, setSearchQuery] = useState('')
     const [activeTab, setActiveTab] = useState<'scanner' | 'checkins' | 'registered'>('scanner')
     const [showEventDropdown, setShowEventDropdown] = useState(false)
+    const [checkingInId, setCheckingInId] = useState<string | null>(null)
+    const [statusFilter, setStatusFilter] = useState<'all' | 'checked' | 'pending'>('all')
 
     const scannerRef = useRef<Html5Qrcode | null>(null)
 
@@ -108,7 +110,40 @@ export default function ScannerPage() {
     )
 
     const checkedInAttendees = filteredAttendees.filter(a => a.attended)
-    const registeredAttendees = filteredAttendees
+    const registeredAttendees = filteredAttendees.filter(a => {
+        if (statusFilter === 'checked') return a.attended
+        if (statusFilter === 'pending') return !a.attended
+        return true // 'all'
+    })
+
+    // Manual check-in handler for when QR scanning fails
+    const handleManualCheckIn = async (attendeeId: string) => {
+        if (!selectedEvent || checkingInId) return
+
+        setCheckingInId(attendeeId)
+        try {
+            const response = await fetch(`/api/events/${selectedEvent}/checkin`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ registrationId: attendeeId })
+            })
+
+            const result = await response.json()
+
+            if (result.success) {
+                // Refresh the attendee list to show updated status
+                fetchAttendees()
+            } else {
+                console.error('Manual check-in failed:', result.message)
+                alert(result.message || 'Check-in failed. Please try again.')
+            }
+        } catch (error) {
+            console.error('Manual check-in error:', error)
+            alert('Check-in failed. Please try again.')
+        } finally {
+            setCheckingInId(null)
+        }
+    }
 
     const handleScanSuccess = async (decodedText: string) => {
         setIsScanning(true)
@@ -524,6 +559,43 @@ export default function ScannerPage() {
                             />
                         </div>
 
+                        {/* Status Filter */}
+                        <div className="flex gap-2 mb-4">
+                            <button
+                                onClick={() => setStatusFilter('all')}
+                                className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${statusFilter === 'all'
+                                    ? 'bg-white/10 text-white'
+                                    : 'text-gray-400 hover:text-white hover:bg-white/5'
+                                    }`}
+                            >
+                                All ({filteredAttendees.length})
+                            </button>
+                            <button
+                                onClick={() => setStatusFilter('checked')}
+                                className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${statusFilter === 'checked'
+                                    ? 'bg-green-600/20 text-green-400 border border-green-500/30'
+                                    : 'text-gray-400 hover:text-green-400 hover:bg-green-500/10'
+                                    }`}
+                            >
+                                <span className="flex items-center justify-center gap-1.5">
+                                    <CheckCircle className="w-4 h-4" />
+                                    Checked ({stats.checkedIn})
+                                </span>
+                            </button>
+                            <button
+                                onClick={() => setStatusFilter('pending')}
+                                className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${statusFilter === 'pending'
+                                    ? 'bg-amber-600/20 text-amber-400 border border-amber-500/30'
+                                    : 'text-gray-400 hover:text-amber-400 hover:bg-amber-500/10'
+                                    }`}
+                            >
+                                <span className="flex items-center justify-center gap-1.5">
+                                    <Clock className="w-4 h-4" />
+                                    Pending ({stats.pending})
+                                </span>
+                            </button>
+                        </div>
+
                         {/* List */}
                         <div className="space-y-2">
                             {registeredAttendees.length === 0 ? (
@@ -553,7 +625,24 @@ export default function ScannerPage() {
                                         {attendee.attended ? (
                                             <CheckCircle className="w-5 h-5 text-green-500 flex-shrink-0" />
                                         ) : (
-                                            <Clock className="w-5 h-5 text-gray-500 flex-shrink-0" />
+                                            <button
+                                                onClick={() => handleManualCheckIn(attendee.id)}
+                                                disabled={checkingInId === attendee.id}
+                                                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium flex-shrink-0"
+                                                title="Manual Check-in"
+                                            >
+                                                {checkingInId === attendee.id ? (
+                                                    <>
+                                                        <Loader2 className="w-4 h-4 animate-spin" />
+                                                        <span className="hidden sm:inline">Checking...</span>
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        <UserPlus className="w-4 h-4" />
+                                                        <span className="hidden sm:inline">Check In</span>
+                                                    </>
+                                                )}
+                                            </button>
                                         )}
                                     </div>
                                 ))

--- a/app/api/events/[eventId]/checkin/route.ts
+++ b/app/api/events/[eventId]/checkin/route.ts
@@ -1,0 +1,121 @@
+import { createClient } from '@supabase/supabase-js'
+import { NextRequest, NextResponse } from 'next/server'
+import { awardDailyXP } from '@/lib/xp'
+import { auth } from '@/lib/auth'
+import { checkRateLimit, getClientIdentifier } from '@/lib/rate-limit'
+
+const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+/**
+ * Manual check-in API for offline events
+ * This allows admins to check-in participants without requiring QR code scanning
+ * Useful when QR scanning fails or for managing offline event attendance
+ */
+export async function POST(
+    req: NextRequest,
+    { params }: { params: Promise<{ eventId: string }> }
+) {
+    // Security: Verify only admins can mark attendance
+    const session = await auth()
+    if (!session || !session.user || !['admin', 'super_admin'].includes(session.user.role)) {
+        return NextResponse.json({ success: false, message: 'Unauthorized - Admin access required' }, { status: 401 })
+    }
+
+    // Rate limiting: 30 check-ins per minute per user
+    const rateLimit = checkRateLimit(
+        getClientIdentifier(req, session.user.id),
+        { limit: 30, windowSeconds: 60 }
+    )
+    if (!rateLimit.success) {
+        return NextResponse.json({
+            success: false,
+            message: 'Too many requests. Please slow down.'
+        }, { status: 429 })
+    }
+
+    try {
+        const { eventId } = await params
+        const body = await req.json()
+        const { registrationId } = body
+
+        if (!registrationId) {
+            return NextResponse.json({ success: false, message: 'Registration ID is required' }, { status: 400 })
+        }
+
+        // 1. Find Registration
+        const { data: registration, error: regError } = await supabase
+            .from('registrations')
+            .select('*, events(*)')
+            .eq('id', registrationId)
+            .eq('event_id', eventId)
+            .single()
+
+        if (regError || !registration) {
+            return NextResponse.json({ success: false, message: 'Registration not found' }, { status: 404 })
+        }
+
+        // 2. Check if already marked
+        if (registration.attended) {
+            // Get user name for display
+            const { data: existingUser } = await supabase
+                .schema('next_auth' as unknown as 'public')
+                .from('users')
+                .select('name')
+                .eq('id', registration.user_id)
+                .single()
+
+            return NextResponse.json({
+                success: false,
+                message: 'Already checked in',
+                userName: existingUser?.name || 'Attendee'
+            }, { status: 400 })
+        }
+
+        // 3. Mark as attended
+        const { error: updateError } = await supabase
+            .from('registrations')
+            .update({ attended: true })
+            .eq('id', registration.id)
+
+        if (updateError) {
+            return NextResponse.json({ success: false, message: 'Failed to update attendance' }, { status: 500 })
+        }
+
+        // 4. Award daily XP for attendance (distributes XP across event days)
+        const xpResult = await awardDailyXP(registration.user_id, eventId, {
+            event_type: registration.events?.event_type,
+            difficulty_level: registration.events?.difficulty_level,
+            start_time: registration.events?.start_time,
+            end_time: registration.events?.end_time,
+            is_multi_day: registration.events?.is_multi_day
+        })
+
+        // 5. Get User Name from next_auth schema
+        const { data: user } = await supabase
+            .schema('next_auth' as unknown as 'public')
+            .from('users')
+            .select('name')
+            .eq('id', registration.user_id)
+            .single()
+
+        return NextResponse.json({
+            success: true,
+            message: 'Manual check-in successful',
+            userName: user?.name || 'Attendee',
+            xpAwarded: xpResult.xpAwarded,
+            xpMessage: xpResult.message,
+            // Daily XP distribution info
+            dailyXP: xpResult.dailyXP,
+            eventDays: xpResult.eventDays,
+            daysCheckedIn: xpResult.daysCheckedIn,
+            remainingDays: xpResult.remainingDays
+        })
+
+    } catch (err) {
+        console.error('Manual Check-in Error:', err)
+        return NextResponse.json({ success: false, message: 'Server error' }, { status: 500 })
+    }
+}


### PR DESCRIPTION
added a manual check-in button to the scanner section's "All Registered" tab. 
This allows admins to check in participants directly without needing to scan their QR code, which is helpful for offline events when QR scanning or feedback checking isn't working properly.

also added status filter to the "All Registered" tab with three options:

All - Shows all registered participants
Checked (green) - Shows only checked-in participants
Pending (amber) - Shows only participants who haven't checked in yet